### PR TITLE
Pull source code from S3 instead of sourceforge

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,7 @@ CACHE_DIR=$2
 
 # pdftothml
 VERSION="0.39"
-DOWNLOAD=http://downloads.sourceforge.net/project/pdftohtml/pdftohtml/pdftohtml-${VERSION}/pdftohtml-${VERSION}.tar.gz
+DOWNLOAD=https://s3.amazonaws.com/third-party-binaries/pdftohtml-${VERSION}.tar.gz
 FILE_NAME=pdftohtml-${VERSION}.tar.gz
 
 mkdir -p $CACHE_DIR


### PR DESCRIPTION
I copied the source to S3. This is a little safer from a security perspective as sourceforge no longer has the ability to change the source from underneath us.
